### PR TITLE
Update python 3.7.9 image to fix security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM python:3.7.8-alpine3.11
+FROM python:3.7.9-alpine3.11


### PR DESCRIPTION
To fix security vulnerabilities that was shown with trivy needs to be updated to 3.7.9 as 3.7.8 isn't regularly updated anymore