### PR TITLE
upgrade base image to python:3.11-alpine3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine3.17
+FROM python:3.11-alpine3.22
 
 RUN apk update --quiet \
   && apk upgrade libcrypto3 libssl3 --quiet \


### PR DESCRIPTION
- Updated base image from Alpine 3.17 to 3.22
- Resolved EOL warning for unsupported Alpine version
- Ensured continued security patch coverage for OS packages