### PR TITLE
force clean rebuild and base image refresh in drone pipeline

### DIFF
--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -104,6 +104,9 @@ steps:
     repo: quay.io/ukhomeofficedigital/dq-python-alpine
     tags:
     - b-gcc-musl-${DRONE_BUILD_NUMBER}
+    pull_image: true     # always pull base image
+    no_cache: true       # disable layer cach
+
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password

--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -19,6 +19,8 @@ steps:
     tags:
     - ${DRONE_COMMIT_SHA}
     - dev-${DRONE_BUILD_NUMBER}
+    pull_image: true     # always pull base image
+    no_cache: true       # disable layer cach
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -51,6 +53,8 @@ steps:
     tags:
     - ${DRONE_COMMIT_SHA}
     - gcc-musl-dev-${DRONE_BUILD_NUMBER}
+    pull_image: true     # always pull base image
+    no_cache: true       # disable layer cach
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -83,6 +87,8 @@ steps:
     tags:
     - b${DRONE_BUILD_NUMBER}
     - latest
+    pull_image: true     # always pull base image
+    no_cache: true       # disable layer cach
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password


### PR DESCRIPTION
- Enabled `pull_image: true` to always fetch latest base image
- Enabled `no_cache: true` to prevent reuse of stale Docker layers
- Updated docker build steps to avoid using outdated Alpine 3.17 base
- Ensures rebuilt images use python:3.11-alpine3.22 as defined in Dockerfile